### PR TITLE
estimate_marginal_models and roll_residuals modifications

### DIFF
--- a/R/estimate_marginal_models.R
+++ b/R/estimate_marginal_models.R
@@ -93,7 +93,7 @@ estimate_marginal_models <- function(data,
           # extract the coefficients for the window
           coefs <- roll@model$coef[[window]]$coef[, 1]
           spec <- rugarch::ugarchspec(
-            mean.model = list(armaOrder = arma_order[2:3], include.mean = arma_order[1]),
+            mean.model = list(armaOrder = arma_order[2:3], include.mean = (arma_order[1]>0)),
             variance.model =  list(garchOrder = garch_order), 
             distribution.model = roll_distribution,
             fixed.pars = coefs

--- a/R/estimate_marginal_models.R
+++ b/R/estimate_marginal_models.R
@@ -80,6 +80,9 @@ estimate_marginal_models <- function(data,
         data.table::as.data.table()
       # extract the conditional innovations distribution
       roll_distribution <- roll@model$spec@model$modeldesc$distribution
+      #extract the ARMA and GARCH order considered
+      arma_order <- roll@model$spec@model$modelinc[1:3]
+      garch_order <- roll@model$spec@model$modelinc[8:9]
       # get the residuals for each window and store all relevant residuals
       # for the current asset in one data.table whose columns are specified
       # below
@@ -90,6 +93,8 @@ estimate_marginal_models <- function(data,
           # extract the coefficients for the window
           coefs <- roll@model$coef[[window]]$coef[, 1]
           spec <- rugarch::ugarchspec(
+            mean.model = list(armaOrder = arma_order[2:3], include.mean = arma_order[1]),
+            variance.model =  list(garchOrder = garch_order), 
             distribution.model = roll_distribution,
             fixed.pars = coefs
           )

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,7 +25,11 @@ roll_residuals <- function(ugarchroll, roll_num = 1) {
   refit_size <- ugarchroll@model$refit.every
   distribution <- ugarchroll@model$spec@model$modeldesc$distribution
   coefs <- ugarchroll@model$coef[[roll_num]]$coef[, 1]
+  arma_order <- ugarchroll@model$spec@model$modelinc[1:3]
+  garch_order <- ugarchroll@model$spec@model$modelinc[8:9]
   spec <- rugarch::ugarchspec(
+    mean.model = list(armaOrder = arma_order[2:3], include.mean = arma_order[1]),
+    variance.model =  list(garchOrder = garch_order),
     distribution.model = distribution,
     fixed.pars = coefs
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,7 @@ roll_residuals <- function(ugarchroll, roll_num = 1) {
   arma_order <- ugarchroll@model$spec@model$modelinc[1:3]
   garch_order <- ugarchroll@model$spec@model$modelinc[8:9]
   spec <- rugarch::ugarchspec(
-    mean.model = list(armaOrder = arma_order[2:3], include.mean = arma_order[1]),
+    mean.model = list(armaOrder = arma_order[2:3], include.mean = (arma_order[1]>0)),
     variance.model =  list(garchOrder = garch_order),
     distribution.model = distribution,
     fixed.pars = coefs


### PR DESCRIPTION
I have included the arma and garch order in the specifications of both functions.
For them, I have first extract the value and save in the variables "arma_order" and "garch_order". Then, I have used those values in the "mean.model" and "variance.model" respectively in rugarch::ugarchspec function (doing the same for both functions: estimate_marginal_models and roll_residuals.